### PR TITLE
Claim version

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -47,10 +47,10 @@ jobs:
     - name: Publish on NuGet
       run: dotnet nuget push *.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --no-symbols --skip-duplicate
       
-#    - name: Publish on GitHub
-#      run: |
-#          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
-#          dotnet nuget push **\*.nupkg --source github --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
+    - name: Publish on GitHub
+      run: |
+        dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+        dotnet nuget push **\*.nupkg --source github --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
 
 #    - name: Create release
 #      uses: actions/create-release@v1

--- a/IdentityManager.API/Program.cs
+++ b/IdentityManager.API/Program.cs
@@ -37,6 +37,7 @@ public class Program
         //...
 
         var app = builder.Build();
+        app.UseHttpsRedirection();
 
         //Use this MinimalApiExceptionMiddleware in your pipeline if you don't need to add new exceptions.
         app.UseMiddleware<MinimalApiExceptionMiddleware>();
@@ -46,16 +47,17 @@ public class Program
         //the exceptions you need.
         //app.UseMiddleware<ExtendedExceptionMiddleware>();
 
-        app.UseRouting();
-        app.UseStatusCodePages();
-
         if (app.Environment.IsDevelopment())
         {
-            app.UseSwagger().UseSwaggerUI(options =>
-            {
-                options.SwaggerEndpoint("/swagger/v1/swagger.json", builder.Environment.ApplicationName);
-            });
+            app.UseSwagger()
+                .UseSwaggerUI(options =>
+                {
+                    options.SwaggerEndpoint("/swagger/v1/swagger.json", builder.Environment.ApplicationName);
+                });
         }
+
+        app.UseStatusCodePages();
+        app.UseRouting();
 
         app.UseCors("cors");
 

--- a/IdentityManager.API/Properties/launchSettings.json
+++ b/IdentityManager.API/Properties/launchSettings.json
@@ -9,15 +9,15 @@
     }
   },
   "profiles": {
-    "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5263",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+    "IdentityManager": {
+        "commandName": "Project",
+        "dotnetRunMessages": true,
+        "launchBrowser": true,
+        "launchUrl": "swagger",
+        "applicationUrl": "https://localhost:7263;http://localhost:5263",
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        }
     },
     "IIS Express": {
       "commandName": "IISExpress",

--- a/IdentityManager.API/appsettings.json
+++ b/IdentityManager.API/appsettings.json
@@ -14,8 +14,8 @@
         "Issuer": "[ISSUER]",
         "Audience": "[AUDIENCE]",
         "SecurityKey": "[SECURITY-KEY-512-CHAR]",
-        "AccessTokenExpirationMinutes": "60",
-        "RefreshTokenExpirationMinutes": "60"
+        "AccessTokenExpirationMinutes": 60,
+        "RefreshTokenExpirationMinutes": 60
     },
     "NetIdentityOptions": {
         "RequireUniqueEmail": true,

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Adding this sections in the _appsettings.json_ file:
         "Issuer": "[ISSUER]",
         "Audience": "[AUDIENCE]",
         "SecurityKey": "[SECURITY-KEY-512-CHAR]",
-        "AccessTokenExpirationMinutes": "60",
-        "RefreshTokenExpirationMinutes": "60"
+        "AccessTokenExpirationMinutes": 60,
+        "RefreshTokenExpirationMinutes": 60
     },
     "NetIdentityOptions": {
         "RequireUniqueEmail": true,

--- a/src/MinimalApi.Identity.API/Constants/ApplicationConstants.cs
+++ b/src/MinimalApi.Identity.API/Constants/ApplicationConstants.cs
@@ -1,9 +1,0 @@
-﻿using MinimalApi.Identity.API.Options;
-
-namespace MinimalApi.Identity.API.Constants;
-
-internal class ApplicationConstants
-{
-    internal static JwtOptions jwtOptions = new JwtOptions();
-    internal static NetIdentityOptions identityOptions = new NetIdentityOptions();
-}

--- a/src/MinimalApi.Identity.API/Constants/MessageApi.cs
+++ b/src/MinimalApi.Identity.API/Constants/MessageApi.cs
@@ -10,7 +10,6 @@ public static class MessageApi
     public const string ErrorConfirmEmail = "Error confirming your email";
     public const string ErrorConfirmEmailChange = "Error changing email";
     public const string ErrorChangeUsername = "Error changing username";
-    //public const string EmailUnchanged = "Your email is unchanged";
     public const string NewEmailIsRequired = "New email is required";
     public const string SendEmailForChangeEmail = "Confirmation link to change email sent. Please check your email";
     public const string SendEmailResetPassword = "Email sent successfully";

--- a/src/MinimalApi.Identity.API/Endpoints/AccountEndpoints.cs
+++ b/src/MinimalApi.Identity.API/Endpoints/AccountEndpoints.cs
@@ -32,7 +32,6 @@ public class AccountEndpoints : IEndpointRouteHandlerBuilder
             return await accountService.ConfirmEmailAsync(userId, token);
         })
         .Produces<Ok<string>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status400BadRequest)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest)
         .WithOpenApi(opt =>
         {
@@ -51,9 +50,6 @@ public class AccountEndpoints : IEndpointRouteHandlerBuilder
             return await accountService.ChangeEmailAsync(inputModel);
         })
         .Produces<Ok<string>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status400BadRequest)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status422UnprocessableEntity)
         .WithValidation<ChangeEmailModel>()
         .WithOpenApi(opt =>
@@ -75,7 +71,6 @@ public class AccountEndpoints : IEndpointRouteHandlerBuilder
             return await accountService.ConfirmEmailChangeAsync(userId, email, token);
         })
         .Produces<Ok<string>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status400BadRequest)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest)
         .WithOpenApi(opt =>
         {

--- a/src/MinimalApi.Identity.API/Endpoints/AuthEndpoints.cs
+++ b/src/MinimalApi.Identity.API/Endpoints/AuthEndpoints.cs
@@ -32,8 +32,6 @@ public class AuthEndpoints : IEndpointRouteHandlerBuilder
             return await authService.RegisterAsync(inputModel);
         })
         .Produces<Ok<string>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status400BadRequest)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status422UnprocessableEntity)
         .WithValidation<RegisterModel>()
         .WithOpenApi(opt =>
@@ -53,8 +51,6 @@ public class AuthEndpoints : IEndpointRouteHandlerBuilder
             return await authService.LoginAsync(inputModel);
         })
         .Produces<Ok<AuthResponseModel>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status400BadRequest)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status422UnprocessableEntity)
         .WithValidation<LoginModel>()
         .WithOpenApi(opt =>

--- a/src/MinimalApi.Identity.API/Endpoints/AuthPolicyEndpoints.cs
+++ b/src/MinimalApi.Identity.API/Endpoints/AuthPolicyEndpoints.cs
@@ -31,8 +31,6 @@ public class AuthPolicyEndpoints : IEndpointRouteHandlerBuilder
             return await authPolicyService.GetAllPoliciesAsync();
         })
         .Produces<Ok<List<PolicyResponseModel>>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
         .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound)
         .RequireAuthorization(nameof(Permissions.AuthPolicyRead))
         .WithOpenApi(opt =>
@@ -53,9 +51,6 @@ public class AuthPolicyEndpoints : IEndpointRouteHandlerBuilder
             return await authPolicyService.CreatePolicyAsync(inputModel);
         })
         .Produces<Ok<string>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status400BadRequest)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.AuthPolicyWrite))
         .WithValidation<CreatePolicyModel>()
@@ -77,9 +72,6 @@ public class AuthPolicyEndpoints : IEndpointRouteHandlerBuilder
             return await authPolicyService.DeletePolicyAsync(inputModel);
         })
         .Produces<Ok<string>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status400BadRequest)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.AuthPolicyWrite))
         .WithValidation<DeletePolicyModel>()

--- a/src/MinimalApi.Identity.API/Endpoints/ClaimsEndpoints.cs
+++ b/src/MinimalApi.Identity.API/Endpoints/ClaimsEndpoints.cs
@@ -31,8 +31,6 @@ public class ClaimsEndpoints : IEndpointRouteHandlerBuilder
             return await claimsService.GetAllClaimsAsync();
         })
         .Produces<Ok<List<ClaimResponseModel>>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
         .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound)
         .RequireAuthorization(nameof(Permissions.ClaimRead))
         .WithOpenApi(opt =>
@@ -53,9 +51,6 @@ public class ClaimsEndpoints : IEndpointRouteHandlerBuilder
             return await claimsService.CreateClaimAsync(inputModel);
         })
         .Produces<Ok<string>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status400BadRequest)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.ClaimWrite))
         .WithValidation<CreateClaimModel>()
@@ -77,9 +72,6 @@ public class ClaimsEndpoints : IEndpointRouteHandlerBuilder
             return await claimsService.AssignClaimAsync(inputModel);
         })
         .Produces<Ok<string>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.ClaimWrite))
         .WithValidation<AssignClaimModel>()
@@ -101,9 +93,6 @@ public class ClaimsEndpoints : IEndpointRouteHandlerBuilder
             return await claimService.RevokeClaimAsync(inputModel);
         })
         .Produces<Ok<string>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.ClaimWrite))
         .WithValidation<RevokeClaimModel>()
@@ -125,9 +114,6 @@ public class ClaimsEndpoints : IEndpointRouteHandlerBuilder
             return await claimsService.DeleteClaimAsync(inputModel);
         })
         .Produces<Ok<string>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status400BadRequest)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.ClaimWrite))
         .WithValidation<DeleteClaimModel>()

--- a/src/MinimalApi.Identity.API/Endpoints/LicenzeEndpoints.cs
+++ b/src/MinimalApi.Identity.API/Endpoints/LicenzeEndpoints.cs
@@ -31,8 +31,6 @@ public class LicenzeEndpoints : IEndpointRouteHandlerBuilder
             return await licenseService.GetAllLicensesAsync();
         })
         .Produces<Ok<List<LicenseResponseModel>>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
         .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound)
         .RequireAuthorization(nameof(Permissions.LicenzaRead))
         .WithOpenApi(opt =>
@@ -53,8 +51,6 @@ public class LicenzeEndpoints : IEndpointRouteHandlerBuilder
             return await licenseService.CreateLicenseAsync(inputModel);
         })
         .Produces<Ok<string>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.LicenzaWrite))
         .WithValidation<CreateLicenseModel>()
@@ -75,9 +71,6 @@ public class LicenzeEndpoints : IEndpointRouteHandlerBuilder
             return await licenseService.AssignLicenseAsync(inputModel);
         })
         .Produces<Ok<string>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.LicenzaWrite))
         .WithValidation<AssignLicenseModel>()
@@ -99,9 +92,6 @@ public class LicenzeEndpoints : IEndpointRouteHandlerBuilder
             return await licenseService.RevokeLicenseAsync(inputModel);
         })
         .Produces<Ok<string>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.LicenzaWrite))
         .WithValidation<RevokeLicenseModel>()
@@ -123,10 +113,6 @@ public class LicenzeEndpoints : IEndpointRouteHandlerBuilder
             return await licenseService.DeleteLicenseAsync(inputModel);
         })
         .Produces<string>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status400BadRequest)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.LicenzaWrite))
         .WithValidation<DeleteLicenseModel>()

--- a/src/MinimalApi.Identity.API/Endpoints/ModuliEndpoints.cs
+++ b/src/MinimalApi.Identity.API/Endpoints/ModuliEndpoints.cs
@@ -31,8 +31,6 @@ public class ModuliEndpoints : IEndpointRouteHandlerBuilder
             return await moduleService.GetAllModulesAsync();
         })
         .Produces<Ok<List<ModuleResponseModel>>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
         .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound)
         .RequireAuthorization(nameof(Permissions.ModuloRead))
         .WithOpenApi(opt =>
@@ -53,8 +51,6 @@ public class ModuliEndpoints : IEndpointRouteHandlerBuilder
             return await moduleService.CreateModuleAsync(inputModel);
         })
         .Produces<Ok<string>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.ModuloWrite))
         .WithValidation<CreateModuleModel>()
@@ -75,9 +71,6 @@ public class ModuliEndpoints : IEndpointRouteHandlerBuilder
             return await moduleService.AssignModuleAsync(inputModel);
         })
         .Produces<Ok<string>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.ModuloWrite))
         .WithValidation<AssignModuleModel>()
@@ -99,9 +92,6 @@ public class ModuliEndpoints : IEndpointRouteHandlerBuilder
             return await moduleService.RevokeModuleAsync(inputModel);
         })
         .Produces<Ok<string>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.ModuloWrite))
         .WithValidation<RevokeModuleModel>()
@@ -123,10 +113,6 @@ public class ModuliEndpoints : IEndpointRouteHandlerBuilder
             return await moduleService.DeleteModuleAsync(inputModel);
         })
         .Produces<string>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status400BadRequest)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.ModuloWrite))
         .WithValidation<DeleteModuleModel>()

--- a/src/MinimalApi.Identity.API/Endpoints/ProfilesEndpoints.cs
+++ b/src/MinimalApi.Identity.API/Endpoints/ProfilesEndpoints.cs
@@ -30,8 +30,6 @@ public class ProfilesEndpoints : IEndpointRouteHandlerBuilder
             return TypedResults.Ok(await profileService.GetProfilesAsync());
         })
         .Produces<List<UserProfileModel>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
         .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound)
         .RequireAuthorization(nameof(Permissions.ProfiloRead))
         .WithOpenApi(opt =>
@@ -52,8 +50,6 @@ public class ProfilesEndpoints : IEndpointRouteHandlerBuilder
             return TypedResults.Ok(await profileService.GetProfileAsync(userId));
         })
         .Produces<UserProfileModel>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
         .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound)
         .RequireAuthorization(nameof(Permissions.ProfiloRead))
         .WithOpenApi(opt =>
@@ -63,7 +59,6 @@ public class ProfilesEndpoints : IEndpointRouteHandlerBuilder
 
             opt.Response(StatusCodes.Status200OK).Description = "User profile retrieved successfully";
             opt.Response(StatusCodes.Status401Unauthorized).Description = "Unauthorized";
-            //opt.Response(StatusCodes.Status403Forbidden).Description = "Forbidden";
             opt.Response(StatusCodes.Status404NotFound).Description = "Not found";
             return opt;
         });
@@ -74,8 +69,6 @@ public class ProfilesEndpoints : IEndpointRouteHandlerBuilder
             return TypedResults.Ok(await profileService.ChangeEnablementStatusUserProfileAsync(inputModel));
         })
         .Produces<UserProfileModel>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound)
         .RequireAuthorization(nameof(Permissions.ProfiloRead))
         .WithOpenApi(opt =>
@@ -86,7 +79,6 @@ public class ProfilesEndpoints : IEndpointRouteHandlerBuilder
             opt.Response(StatusCodes.Status200OK).Description = "User profile retrieved successfully";
             opt.Response(StatusCodes.Status400BadRequest).Description = "Bad request";
             opt.Response(StatusCodes.Status401Unauthorized).Description = "Unauthorized";
-            //opt.Response(StatusCodes.Status403Forbidden).Description = "Forbidden";
             opt.Response(StatusCodes.Status404NotFound).Description = "Not found";
             return opt;
         });
@@ -97,10 +89,6 @@ public class ProfilesEndpoints : IEndpointRouteHandlerBuilder
             return TypedResults.Ok(await profileService.EditProfileAsync(inputModel));
         })
         .Produces<string>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status400BadRequest)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.ProfiloWrite))
         .WithValidation<EditUserProfileModel>()

--- a/src/MinimalApi.Identity.API/Endpoints/RolesEndpoints.cs
+++ b/src/MinimalApi.Identity.API/Endpoints/RolesEndpoints.cs
@@ -30,8 +30,6 @@ public class RolesEndpoints : IEndpointRouteHandlerBuilder
             return await roleService.GetAllRolesAsync();
         })
         .Produces<List<RoleResponseModel>>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
         .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound)
         .RequireAuthorization(nameof(Permissions.RuoloRead))
         .WithOpenApi(opt =>
@@ -52,10 +50,6 @@ public class RolesEndpoints : IEndpointRouteHandlerBuilder
             return await roleService.CreateRoleAsync(inputModel);
         })
         .Produces<string>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status400BadRequest)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status409Conflict)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status409Conflict, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.RuoloWrite))
         .WithValidation<CreateRoleModel>()
@@ -78,10 +72,6 @@ public class RolesEndpoints : IEndpointRouteHandlerBuilder
             return await roleService.AssignRoleAsync(inputModel);
         })
         .Produces<string>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status400BadRequest)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.RuoloWrite))
         .WithValidation<AssignRoleModel>()
@@ -104,10 +94,6 @@ public class RolesEndpoints : IEndpointRouteHandlerBuilder
             return await roleService.RevokeRoleAsync(inputModel);
         })
         .Produces<string>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status400BadRequest)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.RuoloWrite))
         .WithValidation<RevokeRoleModel>()
@@ -130,10 +116,6 @@ public class RolesEndpoints : IEndpointRouteHandlerBuilder
             return await roleService.DeleteRoleAsync(inputModel);
         })
         .Produces<string>(StatusCodes.Status200OK)
-        //.ProducesProblem(StatusCodes.Status400BadRequest)
-        //.ProducesProblem(StatusCodes.Status401Unauthorized)
-        //.ProducesProblem(StatusCodes.Status404NotFound)
-        //.ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound, StatusCodes.Status422UnprocessableEntity)
         .RequireAuthorization(nameof(Permissions.RuoloWrite))
         .WithValidation<DeleteRoleModel>()

--- a/src/MinimalApi.Identity.API/Extensions/ServicesExtensions.cs
+++ b/src/MinimalApi.Identity.API/Extensions/ServicesExtensions.cs
@@ -6,13 +6,13 @@ namespace MinimalApi.Identity.API.Extensions;
 
 public static class ServicesExtensions
 {
-    public static T GetSettingsOptions<T>(this IConfiguration configuration, string sectionName) where T : class, new()
-    {
-        var options = configuration.GetSection(sectionName).Get<T>()
-            ?? throw new ArgumentNullException(nameof(sectionName), $"{sectionName} not found");
+    //public static T GetSettingsOptions<T>(this IConfiguration configuration, string sectionName) where T : class, new()
+    //{
+    //    var options = configuration.GetSection(sectionName).Get<T>()
+    //        ?? throw new ArgumentNullException(nameof(sectionName), $"{sectionName} not found");
 
-        return options;
-    }
+    //    return options;
+    //}
 
     public static TOptions AddOptionValidate<TOptions>(this IServiceCollection services, string sectionName) where TOptions : class
     {
@@ -32,8 +32,8 @@ public static class ServicesExtensions
         return options;
     }
 
-    public static IServiceCollection AddRegisterService<TAssembly>(this IServiceCollection services, string stringEndsWith, ServiceLifetime lifetime)
-        where TAssembly : class
+    public static IServiceCollection AddRegisterService<TAssembly>(this IServiceCollection services, string stringEndsWith,
+        ServiceLifetime lifetime) where TAssembly : class
     {
         services.Scan(scan =>
             scan.FromAssemblyOf<TAssembly>()

--- a/src/MinimalApi.Identity.API/HostedServices/AuthorizationPolicyUpdater.cs
+++ b/src/MinimalApi.Identity.API/HostedServices/AuthorizationPolicyUpdater.cs
@@ -1,18 +1,19 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using MinimalApi.Identity.API.Extensions;
+using Microsoft.Extensions.Options;
 using MinimalApi.Identity.API.Options;
 using MinimalApi.Identity.API.Services.Interfaces;
 
 namespace MinimalApi.Identity.API.HostedServices;
 
+//public class AuthorizationPolicyUpdater(IServiceProvider serviceProvider, ILogger<AuthorizationPolicyUpdater> logger, IConfiguration configuration) : IHostedService, IDisposable
 public class AuthorizationPolicyUpdater(IServiceProvider serviceProvider, ILogger<AuthorizationPolicyUpdater> logger,
-    IConfiguration configuration) : IHostedService, IDisposable
+    IOptions<HostedServiceOptions> hostedOptions) : IHostedService, IDisposable
 {
     private Timer? timer;
-    private readonly HostedServiceOptions options = configuration.GetSettingsOptions<HostedServiceOptions>(nameof(HostedServiceOptions));
+    //private readonly HostedServiceOptions options = configuration.GetSettingsOptions<HostedServiceOptions>(nameof(HostedServiceOptions));
+    private readonly HostedServiceOptions options = hostedOptions.Value;
 
     public Task StartAsync(CancellationToken cancellationToken)
     {

--- a/src/MinimalApi.Identity.API/Services/EmailSenderService.cs
+++ b/src/MinimalApi.Identity.API/Services/EmailSenderService.cs
@@ -1,15 +1,15 @@
 ﻿using MailKit.Net.Smtp;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using MimeKit;
 using MinimalApi.Identity.API.Entities;
 using MinimalApi.Identity.API.Enums;
-using MinimalApi.Identity.API.Extensions;
 using MinimalApi.Identity.API.Options;
 using MinimalApi.Identity.API.Services.Interfaces;
 
 namespace MinimalApi.Identity.API.Services;
 
-public class EmailSenderService(IConfiguration configuration, IEmailSavingService emailSaving) : IEmailSenderService
+//public class EmailSenderService(IConfiguration configuration, IEmailSavingService emailSaving) : IEmailSenderService
+public class EmailSenderService(IEmailSavingService emailSaving, IOptions<SmtpOptions> smtpOptions) : IEmailSenderService
 {
     public async Task SendEmailTypeAsync(string email, string callbackUrl, EmailSendingType typeSender)
         => await SendEmailAsync(email, "Confirm your email",
@@ -17,7 +17,8 @@ public class EmailSenderService(IConfiguration configuration, IEmailSavingServic
 
     private async Task SendEmailAsync(string emailTo, string emailSubject, string emailMessage, EmailSendingType emailSendingType)
     {
-        var options = configuration.GetSettingsOptions<SmtpOptions>(nameof(SmtpOptions));
+        //var options = configuration.GetSettingsOptions<SmtpOptions>(nameof(SmtpOptions));
+        var options = smtpOptions.Value;
 
         using SmtpClient client = new();
         MimeMessage message = new();

--- a/src/MinimalApi.Identity.API/Services/LicenseService.cs
+++ b/src/MinimalApi.Identity.API/Services/LicenseService.cs
@@ -130,7 +130,6 @@ public class LicenseService(MinimalApiAuthDbContext dbContext, UserManager<Appli
 
     private async Task<bool> CheckLicenseExistAsync(CreateLicenseModel model)
     {
-        return await dbContext.Licenses
-            .AnyAsync(l => l.Name.Equals(model.Name, StringComparison.InvariantCultureIgnoreCase));
+        return await dbContext.Licenses.AnyAsync(l => l.Name.Equals(model.Name, StringComparison.InvariantCultureIgnoreCase));
     }
 }

--- a/src/MinimalApi.Identity.API/Services/ProfileService.cs
+++ b/src/MinimalApi.Identity.API/Services/ProfileService.cs
@@ -36,10 +36,6 @@ public class ProfileService(MinimalApiAuthDbContext dbContext, UserManager<Appli
     public async Task<string> CreateProfileAsync(CreateUserProfileModel model)
     {
         var profile = new UserProfile(model.UserId, model.FirstName, model.LastName);
-        //{
-        //    IsEnabled = true,
-        //    LastDateChangePassword = DateOnly.FromDateTime(DateTime.Now)
-        //};
 
         profile.ChangeUserEnabled(true);
         profile.ChangeLastDateChangePassword(DateOnly.FromDateTime(DateTime.Now));

--- a/src/MinimalApi.Identity.API/Validator/Claims/CreateClaimValidator.cs
+++ b/src/MinimalApi.Identity.API/Validator/Claims/CreateClaimValidator.cs
@@ -1,6 +1,5 @@
 ﻿using FluentValidation;
-using Microsoft.Extensions.Configuration;
-using MinimalApi.Identity.API.Extensions;
+using Microsoft.Extensions.Options;
 using MinimalApi.Identity.API.Models;
 using MinimalApi.Identity.API.Options;
 
@@ -8,9 +7,11 @@ namespace MinimalApi.Identity.API.Validator.Claims;
 
 public class CreateClaimValidator : AbstractValidator<CreateClaimModel>
 {
-    public CreateClaimValidator(IConfiguration configuration)
+    //public CreateClaimValidator(IConfiguration configuration)
+    public CreateClaimValidator(IOptions<ApiValidationOptions> options)
     {
-        var validationOptions = configuration.GetSettingsOptions<ApiValidationOptions>(nameof(ApiValidationOptions));
+        //var validationOptions = configuration.GetSettingsOptions<ApiValidationOptions>(nameof(ApiValidationOptions));
+        var validationOptions = options.Value;
 
         RuleFor(x => x.Type)
             .NotEmpty().WithMessage("Type is required");

--- a/src/MinimalApi.Identity.API/Validator/Licenses/CreateLicenseValidator.cs
+++ b/src/MinimalApi.Identity.API/Validator/Licenses/CreateLicenseValidator.cs
@@ -1,6 +1,5 @@
 ﻿using FluentValidation;
-using Microsoft.Extensions.Configuration;
-using MinimalApi.Identity.API.Extensions;
+using Microsoft.Extensions.Options;
 using MinimalApi.Identity.API.Models;
 using MinimalApi.Identity.API.Options;
 
@@ -8,9 +7,11 @@ namespace MinimalApi.Identity.API.Validator.Licenses;
 
 public class CreateLicenseValidator : AbstractValidator<CreateLicenseModel>
 {
-    public CreateLicenseValidator(IConfiguration configuration)
+    //public CreateLicenseValidator(IConfiguration configuration)
+    public CreateLicenseValidator(IOptions<ApiValidationOptions> options)
     {
-        var validationOptions = configuration.GetSettingsOptions<ApiValidationOptions>(nameof(ApiValidationOptions));
+        //var validationOptions = configuration.GetSettingsOptions<ApiValidationOptions>(nameof(ApiValidationOptions));
+        var validationOptions = options.Value;
 
         RuleFor(x => x.Name)
             .NotEmpty().WithMessage("Name is required")

--- a/src/MinimalApi.Identity.API/Validator/Modules/CreateModuleValidator.cs
+++ b/src/MinimalApi.Identity.API/Validator/Modules/CreateModuleValidator.cs
@@ -1,6 +1,5 @@
 ﻿using FluentValidation;
-using Microsoft.Extensions.Configuration;
-using MinimalApi.Identity.API.Extensions;
+using Microsoft.Extensions.Options;
 using MinimalApi.Identity.API.Models;
 using MinimalApi.Identity.API.Options;
 
@@ -8,9 +7,11 @@ namespace MinimalApi.Identity.API.Validator.Modules;
 
 public class CreateModuleValidator : AbstractValidator<CreateModuleModel>
 {
-    public CreateModuleValidator(IConfiguration configuration)
+    //public CreateModuleValidator(IConfiguration configuration)
+    public CreateModuleValidator(IOptions<ApiValidationOptions> options)
     {
-        var validationOptions = configuration.GetSettingsOptions<ApiValidationOptions>(nameof(ApiValidationOptions));
+        //var validationOptions = configuration.GetSettingsOptions<ApiValidationOptions>(nameof(ApiValidationOptions));
+        var validationOptions = options.Value;
 
         RuleFor(x => x.Name)
             .NotEmpty().WithMessage("Name is required")

--- a/src/MinimalApi.Identity.API/Validator/Policy/CreatePolicyValidator.cs
+++ b/src/MinimalApi.Identity.API/Validator/Policy/CreatePolicyValidator.cs
@@ -1,6 +1,5 @@
 ﻿using FluentValidation;
-using Microsoft.Extensions.Configuration;
-using MinimalApi.Identity.API.Extensions;
+using Microsoft.Extensions.Options;
 using MinimalApi.Identity.API.Models;
 using MinimalApi.Identity.API.Options;
 
@@ -8,9 +7,11 @@ namespace MinimalApi.Identity.API.Validator.Policy;
 
 public class CreatePolicyValidator : AbstractValidator<CreatePolicyModel>
 {
-    public CreatePolicyValidator(IConfiguration configuration)
+    //public CreatePolicyValidator(IConfiguration configuration)
+    public CreatePolicyValidator(IOptions<ApiValidationOptions> options)
     {
-        var validationOptions = configuration.GetSettingsOptions<ApiValidationOptions>(nameof(ApiValidationOptions));
+        //var validationOptions = configuration.GetSettingsOptions<ApiValidationOptions>(nameof(ApiValidationOptions));
+        var validationOptions = options.Value;
 
         RuleFor(x => x.PolicyName)
             .NotEmpty().WithMessage("Name is required.")

--- a/src/MinimalApi.Identity.API/Validator/Profiles/CreateUserProfileValidator.cs
+++ b/src/MinimalApi.Identity.API/Validator/Profiles/CreateUserProfileValidator.cs
@@ -1,6 +1,5 @@
 ﻿using FluentValidation;
-using Microsoft.Extensions.Configuration;
-using MinimalApi.Identity.API.Extensions;
+using Microsoft.Extensions.Options;
 using MinimalApi.Identity.API.Models;
 using MinimalApi.Identity.API.Options;
 
@@ -8,9 +7,11 @@ namespace MinimalApi.Identity.API.Validator.Profiles;
 
 public class CreateUserProfileValidator : AbstractValidator<CreateUserProfileModel>
 {
-    public CreateUserProfileValidator(IConfiguration configuration)
+    //public CreateUserProfileValidator(IConfiguration configuration)
+    public CreateUserProfileValidator(IOptions<ApiValidationOptions> options)
     {
-        var validationOptions = configuration.GetSettingsOptions<ApiValidationOptions>(nameof(ApiValidationOptions));
+        //var validationOptions = configuration.GetSettingsOptions<ApiValidationOptions>(nameof(ApiValidationOptions));
+        var validationOptions = options.Value;
 
         RuleFor(x => x.UserId)
             .NotEmpty().WithMessage("UserId is required")

--- a/src/MinimalApi.Identity.API/Validator/Profiles/EditUserProfileValidator.cs
+++ b/src/MinimalApi.Identity.API/Validator/Profiles/EditUserProfileValidator.cs
@@ -1,6 +1,5 @@
 ﻿using FluentValidation;
-using Microsoft.Extensions.Configuration;
-using MinimalApi.Identity.API.Extensions;
+using Microsoft.Extensions.Options;
 using MinimalApi.Identity.API.Models;
 using MinimalApi.Identity.API.Options;
 
@@ -8,9 +7,11 @@ namespace MinimalApi.Identity.API.Validator;
 
 public class EditUserProfileValidator : AbstractValidator<EditUserProfileModel>
 {
-    public EditUserProfileValidator(IConfiguration configuration)
+    //public EditUserProfileValidator(IConfiguration configuration)
+    public EditUserProfileValidator(IOptions<ApiValidationOptions> options)
     {
-        var validationOptions = configuration.GetSettingsOptions<ApiValidationOptions>(nameof(ApiValidationOptions));
+        //var validationOptions = configuration.GetSettingsOptions<ApiValidationOptions>(nameof(ApiValidationOptions));
+        var validationOptions = options.Value;
 
         RuleFor(x => x.UserId)
             .NotEmpty().WithMessage("UserId is required")

--- a/src/MinimalApi.Identity.API/Validator/RegisterValidator.cs
+++ b/src/MinimalApi.Identity.API/Validator/RegisterValidator.cs
@@ -1,6 +1,5 @@
 ﻿using FluentValidation;
-using Microsoft.Extensions.Configuration;
-using MinimalApi.Identity.API.Extensions;
+using Microsoft.Extensions.Options;
 using MinimalApi.Identity.API.Models;
 using MinimalApi.Identity.API.Options;
 
@@ -10,10 +9,13 @@ public class RegisterValidator : AbstractValidator<RegisterModel>
 {
     private static int requiredUniqueChars;
 
-    public RegisterValidator(IConfiguration configuration)
+    //public RegisterValidator(IConfiguration configuration)
+    public RegisterValidator(IOptions<NetIdentityOptions> iOptions, IOptions<ApiValidationOptions> vOptions)
     {
-        var identityOptions = configuration.GetSettingsOptions<NetIdentityOptions>(nameof(NetIdentityOptions));
-        var validationOptions = configuration.GetSettingsOptions<ApiValidationOptions>(nameof(ApiValidationOptions));
+        //var identityOptions = configuration.GetSettingsOptions<NetIdentityOptions>(nameof(NetIdentityOptions));
+        var identityOptions = iOptions.Value;
+        //var validationOptions = configuration.GetSettingsOptions<ApiValidationOptions>(nameof(ApiValidationOptions));
+        var validationOptions = vOptions.Value;
 
         RuleFor(x => x.Firstname)
             .NotEmpty().WithMessage("First name is required")

--- a/src/MinimalApi.Identity.API/Validator/Roles/CreateRoleValidator.cs
+++ b/src/MinimalApi.Identity.API/Validator/Roles/CreateRoleValidator.cs
@@ -1,6 +1,5 @@
 ﻿using FluentValidation;
-using Microsoft.Extensions.Configuration;
-using MinimalApi.Identity.API.Extensions;
+using Microsoft.Extensions.Options;
 using MinimalApi.Identity.API.Models;
 using MinimalApi.Identity.API.Options;
 
@@ -8,9 +7,11 @@ namespace MinimalApi.Identity.API.Validator.Roles;
 
 public class CreateRoleValidator : AbstractValidator<CreateRoleModel>
 {
-    public CreateRoleValidator(IConfiguration configuration)
+    //public CreateRoleValidator(IConfiguration configuration, IOptions<ApiValidationOptions> options)
+    public CreateRoleValidator(IOptions<ApiValidationOptions> options)
     {
-        var applicationOptions = configuration.GetSettingsOptions<ApiValidationOptions>(nameof(ApiValidationOptions));
+        //var applicationOptions = configuration.GetSettingsOptions<ApiValidationOptions>(nameof(ApiValidationOptions));
+        var applicationOptions = options.Value;
 
         RuleFor(x => x.Role)
             .NotEmpty().WithMessage("Role is required")


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and organization of the `IdentityManager.API` and related files. The most important changes include re-enabling the GitHub publish step in the workflow, adding HTTPS redirection, modifying middleware and routing order, and updating token expiration configurations. Additionally, there are multiple cleanups in the endpoints to simplify the codebase by removing commented-out code.

Improvements to the workflow:

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L50-R53): Re-enabled the GitHub publish step for NuGet packages.

Enhancements to application configuration and security:

* [`IdentityManager.API/Program.cs`](diffhunk://#diff-94defd3fb9e7c3cc8d0cf7bf98f47b4ca31b9ce3a0802425aed32b9a6356cf83R40): Added `app.UseHttpsRedirection()` and reordered middleware and routing setup for better organization and security. [[1]](diffhunk://#diff-94defd3fb9e7c3cc8d0cf7bf98f47b4ca31b9ce3a0802425aed32b9a6356cf83R40) [[2]](diffhunk://#diff-94defd3fb9e7c3cc8d0cf7bf98f47b4ca31b9ce3a0802425aed32b9a6356cf83L49-R61)
* [`IdentityManager.API/Properties/launchSettings.json`](diffhunk://#diff-052606097eccb0b54da3c8413ca34028e55fc050dbac98b6fbcb37182bf20e0cL12-R17): Updated profile name to `IdentityManager` and added HTTPS URL.
* `IdentityManager.API/appsettings.json` and `README.md`: Changed token expiration values from strings to integers for better type safety. [[1]](diffhunk://#diff-29cbf25792033f71de903dea6f7eaff0f9a6e82c725c6675837b2b37649243cbL17-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-R52)

Codebase simplification:

* [`src/MinimalApi.Identity.API/Constants/ApplicationConstants.cs`](diffhunk://#diff-dcc9fff54c9dfe065c3c19b7b40016029bf453b6f9dea0954dfac94ab7a57220L1-L9): Removed unused `ApplicationConstants` class.
* Multiple files in `src/MinimalApi.Identity.API/Endpoints/`: Removed commented-out `.ProducesProblem` lines to clean up the codebase. [[1]](diffhunk://#diff-3f09b1b3554a38fbb4fe7d5fab50fe5f1257e06d8a6114cce2ac0c22b19846b6L35) [[2]](diffhunk://#diff-3f09b1b3554a38fbb4fe7d5fab50fe5f1257e06d8a6114cce2ac0c22b19846b6L54-L56) [[3]](diffhunk://#diff-3f09b1b3554a38fbb4fe7d5fab50fe5f1257e06d8a6114cce2ac0c22b19846b6L78) [[4]](diffhunk://#diff-eb20ce647a4bd9288a4f2437808922f3cab8abbe64588d7e2c372273dc60d8eaL35-L36) [[5]](diffhunk://#diff-eb20ce647a4bd9288a4f2437808922f3cab8abbe64588d7e2c372273dc60d8eaL56-L57) [[6]](diffhunk://#diff-a6e537a1022a2b54f34b1cb3922b8a36b6386e84d4fdac1a06e8b8e01178aafcL34-L35) [[7]](diffhunk://#diff-a6e537a1022a2b54f34b1cb3922b8a36b6386e84d4fdac1a06e8b8e01178aafcL56-L58) [[8]](diffhunk://#diff-a6e537a1022a2b54f34b1cb3922b8a36b6386e84d4fdac1a06e8b8e01178aafcL80-L82) [[9]](diffhunk://#diff-92991d81fa07bfe0ed1c9577166b17f1610e2af1e70b78cf9bebf4bbd3b77a6bL34-L35) [[10]](diffhunk://#diff-92991d81fa07bfe0ed1c9577166b17f1610e2af1e70b78cf9bebf4bbd3b77a6bL56-L58) [[11]](diffhunk://#diff-92991d81fa07bfe0ed1c9577166b17f1610e2af1e70b78cf9bebf4bbd3b77a6bL80-L82) [[12]](diffhunk://#diff-92991d81fa07bfe0ed1c9577166b17f1610e2af1e70b78cf9bebf4bbd3b77a6bL104-L106) [[13]](diffhunk://#diff-92991d81fa07bfe0ed1c9577166b17f1610e2af1e70b78cf9bebf4bbd3b77a6bL128-L130) [[14]](diffhunk://#diff-d1befb247347d3a576c0ef420a229ad923c53773470307c933055c1b8bfeacf4L34-L35) [[15]](diffhunk://#diff-d1befb247347d3a576c0ef420a229ad923c53773470307c933055c1b8bfeacf4L56-L57) [[16]](diffhunk://#diff-d1befb247347d3a576c0ef420a229ad923c53773470307c933055c1b8bfeacf4L78-L80) [[17]](diffhunk://#diff-d1befb247347d3a576c0ef420a229ad923c53773470307c933055c1b8bfeacf4L102-L104) [[18]](diffhunk://#diff-d1befb247347d3a576c0ef420a229ad923c53773470307c933055c1b8bfeacf4L126-L129) [[19]](diffhunk://#diff-b14d7b174cb1c1fd8d3b8b72e4a5a113c752498fa03f373a572b38be7b9acbe2L34-L35)