### PR TITLE
Claim version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Library for dynamically managing users, roles, claims, modules and license, usin
 
 ### 🏗️ ToDo
 
-- [ ] Replacing generic IResults with specific ones for each services (AccountService, AuthPolicyService)
+- [ ] Replacing generic IResults with specific ones for each services (AccountService)
 - [ ] Add endpoints to handle refresh token (currently generated, but not usable)
 - [ ] Add endpoints to impersonate the user
 - [ ] Add endpoint for forgotten password recovery

--- a/src/MinimalApi.Identity.API/Endpoints/AuthPolicyEndpoints.cs
+++ b/src/MinimalApi.Identity.API/Endpoints/AuthPolicyEndpoints.cs
@@ -26,7 +26,7 @@ public class AuthPolicyEndpoints : IEndpointRouteHandlerBuilder
                 return opt;
             });
 
-        apiGroup.MapGet(EndpointsApi.EndpointsStringEmpty, async Task<IResult> ([FromServices] IAuthPolicyService authPolicyService) =>
+        apiGroup.MapGet(EndpointsApi.EndpointsStringEmpty, async ([FromServices] IAuthPolicyService authPolicyService) =>
         {
             return await authPolicyService.GetAllPoliciesAsync();
         })
@@ -45,7 +45,7 @@ public class AuthPolicyEndpoints : IEndpointRouteHandlerBuilder
             return opt;
         });
 
-        apiGroup.MapPost(EndpointsApi.EndpointsCreateAuthPolicy, async Task<IResult> ([FromServices] IAuthPolicyService authPolicyService,
+        apiGroup.MapPost(EndpointsApi.EndpointsCreateAuthPolicy, async ([FromServices] IAuthPolicyService authPolicyService,
             [FromBody] CreatePolicyModel inputModel) =>
         {
             return await authPolicyService.CreatePolicyAsync(inputModel);
@@ -66,7 +66,7 @@ public class AuthPolicyEndpoints : IEndpointRouteHandlerBuilder
             return opt;
         });
 
-        apiGroup.MapDelete(EndpointsApi.EndpointsDeleteAuthPolicy, async Task<IResult> ([FromServices] IAuthPolicyService authPolicyService,
+        apiGroup.MapDelete(EndpointsApi.EndpointsDeleteAuthPolicy, async ([FromServices] IAuthPolicyService authPolicyService,
             [FromBody] DeletePolicyModel inputModel) =>
         {
             return await authPolicyService.DeletePolicyAsync(inputModel);

--- a/src/MinimalApi.Identity.API/Exceptions/BadRequest/BadRequestPolicyException.cs
+++ b/src/MinimalApi.Identity.API/Exceptions/BadRequest/BadRequestPolicyException.cs
@@ -1,0 +1,13 @@
+﻿namespace MinimalApi.Identity.API.Exceptions.BadRequest;
+
+public class BadRequestPolicyException : Exception
+{
+    public BadRequestPolicyException()
+    { }
+
+    public BadRequestPolicyException(string? message) : base(message)
+    { }
+
+    public BadRequestPolicyException(string? message, Exception? innerException) : base(message, innerException)
+    { }
+}

--- a/src/MinimalApi.Identity.API/Exceptions/Conflict/ConflictPolicyException.cs
+++ b/src/MinimalApi.Identity.API/Exceptions/Conflict/ConflictPolicyException.cs
@@ -1,0 +1,13 @@
+﻿namespace MinimalApi.Identity.API.Exceptions.Conflict;
+
+public class ConflictPolicyException : Exception
+{
+    public ConflictPolicyException()
+    { }
+
+    public ConflictPolicyException(string? message) : base(message)
+    { }
+
+    public ConflictPolicyException(string? message, Exception? innerException) : base(message, innerException)
+    { }
+}

--- a/src/MinimalApi.Identity.API/Exceptions/NotFound/NotFoundPolicyException.cs
+++ b/src/MinimalApi.Identity.API/Exceptions/NotFound/NotFoundPolicyException.cs
@@ -1,0 +1,13 @@
+﻿namespace MinimalApi.Identity.API.Exceptions.NotFound;
+
+public class NotFoundPolicyException : Exception
+{
+    public NotFoundPolicyException()
+    { }
+
+    public NotFoundPolicyException(string? message) : base(message)
+    { }
+
+    public NotFoundPolicyException(string? message, Exception? innerException) : base(message, innerException)
+    { }
+}

--- a/src/MinimalApi.Identity.API/Middleware/MinimalApiExceptionMiddleware.cs
+++ b/src/MinimalApi.Identity.API/Middleware/MinimalApiExceptionMiddleware.cs
@@ -107,15 +107,15 @@ public class MinimalApiExceptionMiddleware(RequestDelegate next, IOptions<Valida
         => exception switch
         {
             ArgumentOutOfRangeException or ArgumentNullException or BadRequestClaimException or
-            BadRequestLicenseException or BadRequestModuleException or BadRequestProfileException or
-            BadRequestRoleException or BadRequestUserException => HttpStatusCode.BadRequest,
+            BadRequestLicenseException or BadRequestModuleException or BadRequestPolicyException or
+            BadRequestProfileException or BadRequestRoleException or BadRequestUserException => HttpStatusCode.BadRequest,
 
-            ConflictClaimException or ConflictLicenseException or ConflictModuleException or
-            ConflictRoleException => HttpStatusCode.Conflict,
+            ConflictClaimException or ConflictLicenseException or ConflictPolicyException or
+            ConflictModuleException or ConflictRoleException => HttpStatusCode.Conflict,
 
             NotFoundActivePoliciesException or NotFoundClaimException or NotFoundLicenseException or
-            NotFoundModuleException or NotFoundProfileException or NotFoundRoleException or
-            NotFoundUserException => HttpStatusCode.NotFound,
+            NotFoundModuleException or NotFoundPolicyException or NotFoundProfileException or
+            NotFoundRoleException or NotFoundUserException => HttpStatusCode.NotFound,
 
             UserIsLockedException or UserTokenIsInvalidException or UserUnknownException or
             UserWithoutPermissionsException => HttpStatusCode.Unauthorized,
@@ -132,6 +132,7 @@ public class MinimalApiExceptionMiddleware(RequestDelegate next, IOptions<Valida
             BadRequestClaimException badRequestClaimException => badRequestClaimException.Message,
             BadRequestLicenseException badRequestLicenseException => badRequestLicenseException.Message,
             BadRequestModuleException badRequestModuleException => badRequestModuleException.Message,
+            BadRequestPolicyException badRequestPolicyException => badRequestPolicyException.Message,
             BadRequestProfileException badRequestProfileException => badRequestProfileException.Message,
             BadRequestRoleException badRequestRoleException => badRequestRoleException.Message,
             BadRequestUserException badRequestUserException => badRequestUserException.Message,
@@ -139,12 +140,14 @@ public class MinimalApiExceptionMiddleware(RequestDelegate next, IOptions<Valida
             ConflictClaimException conflictClaimException => conflictClaimException.Message,
             ConflictLicenseException conflictLicenseException => conflictLicenseException.Message,
             ConflictModuleException conflictModuleException => conflictModuleException.Message,
+            ConflictPolicyException conflictPolicyException => conflictPolicyException.Message,
             ConflictRoleException conflictRoleException => conflictRoleException.Message,
 
             NotFoundActivePoliciesException notFoundActivePoliciesException => notFoundActivePoliciesException.Message,
             NotFoundClaimException notFoundClaimException => notFoundClaimException.Message,
             NotFoundLicenseException notFoundLicenseException => notFoundLicenseException.Message,
             NotFoundModuleException notFoundModuleException => notFoundModuleException.Message,
+            NotFoundPolicyException notFoundPolicyException => notFoundPolicyException.Message,
             NotFoundProfileException notFoundProfileException => notFoundProfileException.Message,
             NotFoundRoleException notFoundRoleException => notFoundRoleException.Message,
             NotFoundUserException notFoundUserException => notFoundUserException.Message,

--- a/src/MinimalApi.Identity.API/Services/Interfaces/IAuthPolicyService.cs
+++ b/src/MinimalApi.Identity.API/Services/Interfaces/IAuthPolicyService.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq.Expressions;
-using Microsoft.AspNetCore.Http;
 using MinimalApi.Identity.API.Entities;
 using MinimalApi.Identity.API.Models;
 
@@ -7,9 +6,9 @@ namespace MinimalApi.Identity.API.Services.Interfaces;
 
 public interface IAuthPolicyService
 {
-    Task<IResult> GetAllPoliciesAsync();
-    Task<IResult> CreatePolicyAsync(CreatePolicyModel model);
-    Task<IResult> DeletePolicyAsync(DeletePolicyModel model);
+    Task<List<PolicyResponseModel>> GetAllPoliciesAsync();
+    Task<string> CreatePolicyAsync(CreatePolicyModel model);
+    Task<string> DeletePolicyAsync(DeletePolicyModel model);
 
     Task<bool> GenerateAuthPoliciesAsync();
     Task<bool> UpdateAuthPoliciesAsync();


### PR DESCRIPTION
This pull request introduces several changes to the `MinimalApi.Identity.API` project, focusing on improving exception handling and refining the `AuthPolicyService` methods. The most important changes include the addition of specific exception classes, modifications to the `AuthPolicyService` methods to use these exceptions, and updates to the middleware to handle the new exceptions.

### Exception Handling Improvements:
* Added new exception classes: `BadRequestPolicyException`, `ConflictPolicyException`, and `NotFoundPolicyException` to the `Exceptions` namespace. [[1]](diffhunk://#diff-1494d960d40779c87f96f04c23bb538bbe5a3cf86a75b5214525ca7033945ab1R1-R13) [[2]](diffhunk://#diff-7a51c621aee816c13585846494fbdddfb1760007690ac39560cc66f61b79bd30R1-R13) [[3]](diffhunk://#diff-656eec0a15529a19bc078f06d14e9ceb1cca2e30bf288000ae8330560f14bda0R1-R13)
* Updated `MinimalApiExceptionMiddleware` to handle the new exceptions, ensuring appropriate HTTP status codes and messages are returned. [[1]](diffhunk://#diff-93671587639a75752cc470b0a92292b94ca257b2a1f7019b44d0da0c4a6e425fL110-R118) [[2]](diffhunk://#diff-93671587639a75752cc470b0a92292b94ca257b2a1f7019b44d0da0c4a6e425fR135-R150)

### AuthPolicyService Method Refinements:
* Modified `GetAllPoliciesAsync`, `CreatePolicyAsync`, and `DeletePolicyAsync` methods in `AuthPolicyService` to throw specific exceptions instead of returning `IResult`. [[1]](diffhunk://#diff-6c23de6c8bd5f81e9725bf2e067eed5c27e1fbffcdc0cddfab19dcd1a45a3328L21-R38) [[2]](diffhunk://#diff-6c23de6c8bd5f81e9725bf2e067eed5c27e1fbffcdc0cddfab19dcd1a45a3328L55-R70)
* Updated the `IAuthPolicyService` interface to reflect the changes in return types for the modified methods.

### Endpoint Definition Updates:
* Simplified endpoint definitions in `AuthPolicyEndpoints.cs` by removing the `Task<IResult>` return type from async methods. [[1]](diffhunk://#diff-a6e537a1022a2b54f34b1cb3922b8a36b6386e84d4fdac1a06e8b8e01178aafcL29-R29) [[2]](diffhunk://#diff-a6e537a1022a2b54f34b1cb3922b8a36b6386e84d4fdac1a06e8b8e01178aafcL48-R48) [[3]](diffhunk://#diff-a6e537a1022a2b54f34b1cb3922b8a36b6386e84d4fdac1a06e8b8e01178aafcL69-R69)

### Documentation Update:
* Updated the `README.md` to reflect the removal of `AuthPolicyService` from the list of services needing specific `IResults`.