### PR TITLE
Claim version

### DIFF
--- a/IdentityManager.API/IdentityManager.API.csproj
+++ b/IdentityManager.API/IdentityManager.API.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
+++ b/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
@@ -19,13 +19,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
     <PackageReference Include="MailKit" Version="4.12.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.15" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.16" />
     <PackageReference Include="Scrutor" Version="6.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
   </ItemGroup>


### PR DESCRIPTION
This pull request updates several NuGet package dependencies across two project files to ensure compatibility and leverage the latest features and fixes. The updates include minor and patch version upgrades for multiple packages.

### Dependency Updates:

* [`IdentityManager.API/IdentityManager.API.csproj`](diffhunk://#diff-474a67afa2cbbbca9101a7effc568d81c2b8b7839463d4ed2145c9f00dd36af6L11-R11): Updated `Microsoft.EntityFrameworkCore.Tools` from version `9.0.4` to `9.0.5`.

* `src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj`:  
  - Updated `FluentValidation.DependencyInjectionExtensions` from version `11.11.0` to `12.0.0`.  
  - Updated `Microsoft.AspNetCore.Identity.EntityFrameworkCore`, `Microsoft.EntityFrameworkCore`, `Microsoft.EntityFrameworkCore.SqlServer`, `Microsoft.AspNetCore.OpenApi`, and `Microsoft.AspNetCore.Authentication.JwtBearer` to their respective latest versions (`8.0.16` and `9.0.5`).