### PR TITLE
Update target framework and Swashbuckle version

### DIFF
--- a/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
+++ b/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Authors>Angelo Pirola</Authors>
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.16" />
     <PackageReference Include="Scrutor" Version="6.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Changed target frameworks to only include .NET 8.0. Updated `Swashbuckle.AspNetCore` package from version 8.1.1 to 8.1.2.