### PR TITLE
Update NuGet package versions in project file

### DIFF
--- a/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
+++ b/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
@@ -26,8 +26,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.16" />
-    <PackageReference Include="Scrutor" Version="6.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
+    <PackageReference Include="Scrutor" Version="6.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgraded `Scrutor` from 6.0.1 to 6.1.0 and `Swashbuckle.AspNetCore` from 8.1.2 to 8.1.4 in `MinimalApi.Identity.API.csproj`. Removed previous versions of these packages.