### PR TITLE
Claim version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Library for dynamically managing users, roles, claims, modules and license, usin
 
 ### 🏗️ ToDo
 
-- [ ] Add endpoint for password change (Reset Password)
 - [ ] Add endpoints for two-factor authentication and management
 - [ ] Add endpoints for downloading and deleting personal data
 - [ ] Test endpoints to impersonate the user

--- a/src/MinimalApi.Identity.API/Constants/MessageApi.cs
+++ b/src/MinimalApi.Identity.API/Constants/MessageApi.cs
@@ -15,6 +15,7 @@ public static class MessageApi
     public const string SendEmailResetPassword = "Please check your email to reset your password";
     public const string ResetPassword = "Password reset successfully";
     public const string ErrorEmailNotConfirmed = "Email not confirmed";
+    public const string ErrorCodeResetPassword = "A code must be supplied for password reset.";
 
     public const string UserCreated = "User created successfully";
     public const string UserNotAllowedLogin = "User is not allowed to sign in";

--- a/src/MinimalApi.Identity.API/Endpoints/AuthEndpoints.cs
+++ b/src/MinimalApi.Identity.API/Endpoints/AuthEndpoints.cs
@@ -131,5 +131,23 @@ public class AuthEndpoints : IEndpointRouteHandlerBuilder
             opt.Response(StatusCodes.Status400BadRequest).Description = "Bad Request";
             return opt;
         });
+
+        apiGroup.MapPost(EndpointsApi.EndpointsResetPassword, async ([FromServices] IAuthService authService,
+            [FromBody] ResetPasswordModel inputModel, [FromRoute] string code) =>
+        {
+            return await authService.ResetPasswordAsync(inputModel, code);
+        })
+        .Produces<Ok<string>>(StatusCodes.Status200OK)
+        .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status422UnprocessableEntity)
+        .WithValidation<ForgotPasswordModel>()
+        .WithOpenApi(opt =>
+        {
+            opt.Description = "Reset password";
+            opt.Summary = "Reset password";
+
+            opt.Response(StatusCodes.Status200OK).Description = "Your password has been reset.";
+            opt.Response(StatusCodes.Status400BadRequest).Description = "Bad Request";
+            return opt;
+        });
     }
 }

--- a/src/MinimalApi.Identity.API/Models/RecordsModel.cs
+++ b/src/MinimalApi.Identity.API/Models/RecordsModel.cs
@@ -3,7 +3,7 @@
 public record class RegisterModel(string Firstname, string Lastname, string Username, string Email, string Password);
 public record class LoginModel(string Username, string Password, bool RememberMe);
 public record class ForgotPasswordModel(string Email);
-//public record class ResetPasswordModel(string Email, string Token, string Password);
+public record class ResetPasswordModel(string Email, string Password, string ConfirmPassword);
 public record class RefreshTokenModel(string AccessToken, string RefreshToken);
 public record class ChangeEmailModel(string Email, string NewEmail);
 public record class ImpersonateUserModel(int UserId);

--- a/src/MinimalApi.Identity.API/Services/AuthService.cs
+++ b/src/MinimalApi.Identity.API/Services/AuthService.cs
@@ -248,6 +248,28 @@ public class AuthService(IOptions<JwtOptions> jOptions, IOptions<NetIdentityOpti
         return MessageApi.SendEmailResetPassword;
     }
 
+    public async Task<string> ResetPasswordAsync(ResetPasswordModel inputModel, string code)
+    {
+        if (code == null)
+        {
+            throw new BadRequestUserException(MessageApi.ErrorCodeResetPassword);
+        }
+
+        var user = await userManager.FindByEmailAsync(inputModel.Email)
+            ?? throw new NotFoundUserException(MessageApi.UserNotFound);
+
+        var result = await userManager.ResetPasswordAsync(user, code, inputModel.Password);
+
+        if (result.Succeeded)
+        {
+            return MessageApi.ResetPassword;
+        }
+        else
+        {
+            throw new BadRequestUserException(result.Errors);
+        }
+    }
+
     #region "Private method"
 
     private static AuthResponseModel CreateToken(List<Claim> claims, JwtOptions jwtOptions)

--- a/src/MinimalApi.Identity.API/Services/Interfaces/IAuthService.cs
+++ b/src/MinimalApi.Identity.API/Services/Interfaces/IAuthService.cs
@@ -10,4 +10,5 @@ public interface IAuthService
     Task<AuthResponseModel> RefreshTokenAsync(RefreshTokenModel model);
     Task<AuthResponseModel> ImpersonateAsync(ImpersonateUserModel inputModel);
     Task<string> ForgotPasswordAsync(ForgotPasswordModel inputModel);
+    Task<string> ResetPasswordAsync(ResetPasswordModel inputModel, string code);
 }

--- a/src/MinimalApi.Identity.API/Validator/ResetPasswordValidator.cs
+++ b/src/MinimalApi.Identity.API/Validator/ResetPasswordValidator.cs
@@ -1,0 +1,25 @@
+﻿using FluentValidation;
+using Microsoft.Extensions.Options;
+using MinimalApi.Identity.API.Models;
+using MinimalApi.Identity.API.Options;
+
+namespace MinimalApi.Identity.API.Validator;
+
+public class ResetPasswordValidator : AbstractValidator<ResetPasswordModel>
+{
+    public ResetPasswordValidator(IOptions<NetIdentityOptions> iOptions)
+    {
+        var identityOptions = iOptions.Value;
+
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("Email is required.")
+            .EmailAddress().WithMessage("Email is not valid.");
+
+        RuleFor(x => x.Password)
+            .NotEmpty().WithMessage("Password is required")
+            .MinimumLength(identityOptions.RequiredLength).WithMessage($"Password must be at least {identityOptions.RequiredLength} characters");
+
+        RuleFor(x => x.ConfirmPassword)
+            .Equal(x => x.Password).WithMessage("The password and confirmation password do not match.");
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature for resetting user passwords, along with associated validations and error handling. It includes updates to the API, models, and services, as well as the addition of a validator to ensure input correctness.

### New Feature: Password Reset Functionality

* **API Endpoint for Reset Password**: Added a new POST endpoint to handle password reset requests, including validation and error response handling. (`src/MinimalApi.Identity.API/Endpoints/AuthEndpoints.cs`)
* **Service Method for Password Reset**: Implemented `ResetPasswordAsync` in `IAuthService` and its implementation to handle the password reset logic, including user lookup, validation of the reset code, and updating the password. (`src/MinimalApi.Identity.API/Services/AuthService.cs`, `src/MinimalApi.Identity.API/Services/Interfaces/IAuthService.cs`) [[1]](diffhunk://#diff-228cf192c20fc1dcbcec6907d4ab6a40af0eda0adbce0daeeeff9f7bc52b331eR251-R272) [[2]](diffhunk://#diff-127c97ea0d40339cdb3ac307ac781b0e006a8a757dc14dc7305d2de2b637c7beR13)

### Model and Validation Enhancements

* **Updated `ResetPasswordModel`**: Modified the model to include `ConfirmPassword` for password confirmation during reset. (`src/MinimalApi.Identity.API/Models/RecordsModel.cs`)
* **Added `ResetPasswordValidator`**: Introduced a new validator to enforce rules for email format, password length, and matching passwords. (`src/MinimalApi.Identity.API/Validator/ResetPasswordValidator.cs`)

### Error Messaging

* **New Error Message for Missing Reset Code**: Added a constant for the error message when the reset code is not provided. (`src/MinimalApi.Identity.API/Constants/MessageApi.cs`)

### Documentation Update

* **Removed ToDo for Password Reset Endpoint**: Updated the README to reflect the completion of the password reset endpoint. (`README.md`)